### PR TITLE
refactor: split client configs and query params

### DIFF
--- a/demo/main.go
+++ b/demo/main.go
@@ -7,9 +7,17 @@ import (
 )
 
 func checkBlockFinalized(height uint64, hash string) {
-	isFinalized, err := sdk.QueryIsBlockBabylonFinalized(sdk.QueryParams{
-		ChainType:      0,
-		ContractAddr:   "osmo1zck32had0fpc4fu34ae58zvs3mjd5yrzs70thw027nfqst7edc3sdqak0m",
+	client, err := sdk.NewClient(sdk.Config{
+		ChainType:    0,
+		ContractAddr: "osmo1zck32had0fpc4fu34ae58zvs3mjd5yrzs70thw027nfqst7edc3sdqak0m",
+	})
+
+	if err != nil {
+		fmt.Printf("error creating client: %v\n", err)
+		return
+	}
+
+	isFinalized, err := client.QueryIsBlockBabylonFinalized(sdk.QueryParams{
 		BlockHeight:    height,
 		BlockHash:      hash,
 		BlockTimestamp: uint64(1718332131),

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -39,7 +39,7 @@ func (config Config) getRpcAddr() (string, error) {
 // such as keyring, chain ID, etc..
 type babylonQueryClient struct {
 	rpcClient rpcclient.Client
-	config    Config
+	config    *Config
 }
 
 // NewClient creates a new babylonQueryClient according to the given config
@@ -56,7 +56,7 @@ func NewClient(config Config) (*babylonQueryClient, error) {
 
 	return &babylonQueryClient{
 		rpcClient: rpcClient,
-		config:    config,
+		config:    &config,
 	}, nil
 }
 

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"fmt"
 	"time"
 
 	"context"
@@ -10,9 +11,27 @@ import (
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 )
 
-// babylonClientConfig defines configuration for the Babylon query client
-type babylonClientConfig struct {
-	rpcAddr string `mapstructure:"rpc-addr"`
+const (
+	BabylonTestnet = 0
+	BabylonMainnet = 1
+)
+
+// Config defines configuration for the Babylon query client
+type Config struct {
+	ChainType    int    `mapstructure:"chain-type"`
+	ContractAddr string `mapstructure:"contract-addr"`
+}
+
+// TODO: replace with babylon RPCs when QuerySmartContractStateRequest query is supported
+func (config Config) getRpcAddr() (string, error) {
+	switch config.ChainType {
+	case BabylonTestnet:
+		return "https://rpc.testnet.osmosis.zone:443", nil
+	case BabylonMainnet:
+		return "https://rpc.testnet.osmosis.zone:443", nil
+	default:
+		return "", fmt.Errorf("unrecognized chain type: %d", config.ChainType)
+	}
 }
 
 // babylonQueryClient is a client that can only perform queries to a Babylon node
@@ -20,17 +39,24 @@ type babylonClientConfig struct {
 // such as keyring, chain ID, etc..
 type babylonQueryClient struct {
 	rpcClient rpcclient.Client
+	config    Config
 }
 
-// newBabylonQueryClient creates a new babylonQueryClient according to the given config
-func newBabylonQueryClient(queryConfig babylonClientConfig) (*babylonQueryClient, error) {
-	rpcClient, err := sdkclient.NewClientFromNode(queryConfig.rpcAddr)
+// NewClient creates a new babylonQueryClient according to the given config
+func NewClient(config Config) (*babylonQueryClient, error) {
+	rpcAddr, err := config.getRpcAddr()
+	if err != nil {
+		return nil, err
+	}
+
+	rpcClient, err := sdkclient.NewClientFromNode(rpcAddr)
 	if err != nil {
 		return nil, err
 	}
 
 	return &babylonQueryClient{
 		rpcClient: rpcClient,
+		config:    config,
 	}, nil
 }
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -2,33 +2,13 @@ package sdk
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 )
 
-const (
-	BabylonTestnet = 0
-	BabylonMainnet = 1
-)
-
 type QueryParams struct {
-	ChainType      int    `mapstructure:"chain-type"`
-	ContractAddr   string `mapstructure:"contract-addr"`
 	BlockHeight    uint64 `mapstructure:"block-height"`
 	BlockHash      string `mapstructure:"block-hash"`
 	BlockTimestamp uint64 `mapstructure:"block-timestamp"`
-}
-
-// TODO: replace with babylon RPCs when QuerySmartContractStateRequest query is supported
-func (queryParams QueryParams) getRpcAddr() (string, error) {
-	switch queryParams.ChainType {
-	case BabylonTestnet:
-		return "https://rpc.testnet.osmosis.zone:443", nil
-	case BabylonMainnet:
-		return "https://rpc.testnet.osmosis.zone:443", nil
-	default:
-		return "", fmt.Errorf("unrecognized chain type: %d", queryParams.ChainType)
-	}
 }
 
 type checkBlockFinalizedData struct {
@@ -60,25 +40,13 @@ func createQueryData(queryParams QueryParams) ([]byte, error) {
 	return data, nil
 }
 
-func QueryIsBlockBabylonFinalized(queryParams QueryParams) (bool, error) {
-	rpcAddr, err := queryParams.getRpcAddr()
-	if err != nil {
-		return false, err
-	}
-
-	queryClient, err := newBabylonQueryClient(babylonClientConfig{
-		rpcAddr: rpcAddr,
-	})
-	if err != nil {
-		return false, err
-	}
-
+func (babylonClient *babylonQueryClient) QueryIsBlockBabylonFinalized(queryParams QueryParams) (bool, error) {
 	queryData, err := createQueryData(queryParams)
 	if err != nil {
 		return false, err
 	}
 
-	resp, err := queryClient.querySmartContractState(queryParams.ContractAddr, queryData)
+	resp, err := babylonClient.querySmartContractState(babylonClient.config.ContractAddr, queryData)
 	if err != nil {
 		return false, err
 	}

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -8,10 +8,8 @@ import (
 
 // this uses a stub contract deployed on Osmosis testnet
 // TODO: replace with one deployed on Babylon chain
-func checkBlockFinalized(height uint64, hash string) (bool, error) {
-	return QueryIsBlockBabylonFinalized(QueryParams{
-		ChainType:      0,
-		ContractAddr:   "osmo1zck32had0fpc4fu34ae58zvs3mjd5yrzs70thw027nfqst7edc3sdqak0m",
+func checkBlockFinalized(client *babylonQueryClient, height uint64, hash string) (bool, error) {
+	return client.QueryIsBlockBabylonFinalized(QueryParams{
 		BlockHeight:    height,
 		BlockHash:      hash,
 		BlockTimestamp: uint64(1718332131),
@@ -20,19 +18,25 @@ func checkBlockFinalized(height uint64, hash string) (bool, error) {
 
 // TestSdk is an e2e test to call into a stub CosmWasm contract deployed on Osmosis testnet
 func TestSdk(t *testing.T) {
+	client, err := NewClient(Config{
+		ChainType:    0,
+		ContractAddr: "osmo1zck32had0fpc4fu34ae58zvs3mjd5yrzs70thw027nfqst7edc3sdqak0m",
+	})
+	require.Nil(t, err)
+
 	blockHashWithoutEnoughVotes := "0x3aa074144a25d3ed71c7353a20c579650e0c56a993444c6156d44bb90b932f0d"
 	blockHashWithEnoughVotes := "stub hash"
 
 	// When the block hash has enough votes
 	for i, expected := range []bool{true, true, true, false} {
-		finaliezd, err := checkBlockFinalized(uint64(i), blockHashWithEnoughVotes)
+		finaliezd, err := checkBlockFinalized(client, uint64(i), blockHashWithEnoughVotes)
 		require.Nil(t, err)
 		require.Equal(t, expected, finaliezd)
 	}
 
 	// When the block hash doesn't have enough votes
 	for i := range 4 {
-		finaliezd, err := checkBlockFinalized(uint64(i), blockHashWithoutEnoughVotes)
+		finaliezd, err := checkBlockFinalized(client, uint64(i), blockHashWithoutEnoughVotes)
 		require.Nil(t, err)
 		require.False(t, finaliezd)
 	}


### PR DESCRIPTION
## Summary

#4 

the only downside is now the caller needs to make one additional call (i.e. `sdk.NewClient()`)

but the design is cleaner

## Test Plan
```
make run
make test
```