### PR TITLE
feat: add `getBlockHeightByTimestamp` API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/CosmWasm/wasmd v0.51.0
 	github.com/cometbft/cometbft v0.38.6
 	github.com/cosmos/cosmos-sdk v0.50.6
-	google.golang.org/grpc v1.63.2
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
@@ -129,7 +129,6 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.18.2 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect
@@ -148,6 +147,7 @@ require (
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda // indirect
+	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/sdk/btc.go
+++ b/sdk/btc.go
@@ -1,0 +1,131 @@
+package sdk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	// TODO: for now using public RPC is fine but it can get rate limited. So in the future, we should
+	// use dedicated RPC or even consider a config param
+	rpcURL = "https://rpc.ankr.com/btc"
+	// No need to search from height 0. Any bitcoin height before the first FP registration works
+	// 848664 is a block at 2024-06-19
+	// https://mempool.space/block/000000000000000000019200f971921bb73e5f16b5098ad71a91849a63964a70
+	btcHeightSearchStart uint64 = 848664
+)
+
+type rpcRequest struct {
+	Method string        `json:"method"`
+	Params []interface{} `json:"params"`
+	ID     string        `json:"id"`
+}
+
+type rpcResponse struct {
+	Result json.RawMessage `json:"result"`
+	Error  interface{}     `json:"error"`
+	ID     string          `json:"id"`
+}
+
+func callRPC(method string, params []interface{}) (json.RawMessage, error) {
+	requestBody, err := json.Marshal(rpcRequest{Method: method, Params: params, ID: "1"})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", rpcURL, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response rpcResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+
+	if response.Error != nil {
+		return nil, fmt.Errorf("RPC error: %v", response.Error)
+	}
+
+	return response.Result, nil
+}
+
+// given a timestamp, search the largest block height whose timestamp is less or equal to it
+func getBlockHeightByTimestamp(targetTimestamp uint64) (uint64, error) {
+	var currentHeight uint64
+	// returns the height of the most-work fully-validated chain.
+	result, err := callRPC("getblockcount", []interface{}{})
+	if err != nil {
+		return 0, err
+	}
+	if err := json.Unmarshal(result, &currentHeight); err != nil {
+		return 0, err
+	}
+
+	lowerBound := btcHeightSearchStart
+	upperBound := currentHeight
+
+	for lowerBound <= upperBound {
+		midHeight := (lowerBound + upperBound) / 2
+
+		// get block hash by height
+		result, err := callRPC("getblockhash", []interface{}{midHeight})
+		if err != nil {
+			return 0, err
+		}
+		var blockHash string
+		if err := json.Unmarshal(result, &blockHash); err != nil {
+			return 0, err
+		}
+
+		// get block header by hash. the header contains info such as the block time expressed in UNIX epoch time
+		result, err = callRPC("getblockheader", []interface{}{blockHash})
+		if err != nil {
+			return 0, err
+		}
+		var blockHeader map[string]interface{}
+		if err := json.Unmarshal(result, &blockHeader); err != nil {
+			return 0, err
+		}
+
+		blockTimestamp := uint64(blockHeader["time"].(float64))
+
+		if blockTimestamp < targetTimestamp {
+			lowerBound = midHeight + 1
+		} else if blockTimestamp > targetTimestamp {
+			upperBound = midHeight - 1
+		} else {
+			return midHeight, nil
+		}
+	}
+
+	// timestamp is in the future (not in the most-work fully-validated chain)
+	// so we cannot determine the height from the timestamp
+	if lowerBound > currentHeight {
+		return 0, nil
+	}
+
+	// timestamp is too old (before we deploy this system)
+	// so we cannot determine the height from the timestamp
+	if upperBound < btcHeightSearchStart {
+		return 0, nil
+	}
+
+	return lowerBound - 1, nil
+}

--- a/sdk/btc_test.go
+++ b/sdk/btc_test.go
@@ -1,0 +1,40 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBtc is an e2e test to call into a stub CosmWasm contract deployed on Osmosis testnet
+// TODO: add more tests for some other edge cases
+func TestBtc(t *testing.T) {
+	var blockHeight uint64
+	var err error
+
+	// timestmap between block 848682 and 848683
+	blockHeight, err = getBlockHeightByTimestamp(uint64(1718840690))
+	require.Nil(t, err)
+	require.Equal(t, uint64(848682), blockHeight)
+
+	// the exact timestamp of block 848682
+	blockHeight, err = getBlockHeightByTimestamp(uint64(1718839311))
+	require.Nil(t, err)
+	require.Equal(t, uint64(848682), blockHeight)
+
+	// the exact timestamp minus one of block 848682
+	blockHeight, err = getBlockHeightByTimestamp(uint64(1718839310))
+	require.Nil(t, err)
+	require.Equal(t, uint64(848681), blockHeight)
+
+	// a timestamp in the future i.e. year 2056
+	blockHeight, err = getBlockHeightByTimestamp(uint64(2718840690))
+	require.Nil(t, err)
+	require.Equal(t, uint64(0), blockHeight)
+
+	// a timestamp in the past i.e. year 2014
+	blockHeight, err = getBlockHeightByTimestamp(uint64(1418840690))
+	require.Nil(t, err)
+	require.Equal(t, uint64(0), blockHeight)
+
+}


### PR DESCRIPTION
## Summary

see details in https://github.com/babylonchain/babylon-contract/pull/174

![image](https://github.com/babylonchain/babylon-da-sdk/assets/111917526/065d5df2-a329-4580-babd-8a745e05f3f7)

## Test Plan

```
$ make test                                                            [21:40:00]
go test ./sdk -v
=== RUN   TestBtc
--- PASS: TestBtc (6.92s)
=== RUN   TestSdk
--- PASS: TestSdk (2.18s)
PASS
ok      github.com/babylonchain/babylon-da-sdk/sdk      9.525s
```

## Next Step
this will be used in `QueryIsBlockBabylonFinalized`