### PR TITLE
feat: clean up the APIs - call `block_votes` query msg

### DIFF
--- a/demo/main.go
+++ b/demo/main.go
@@ -9,7 +9,7 @@ import (
 func checkBlockFinalized(height uint64, hash string) {
 	client, err := sdk.NewClient(sdk.Config{
 		ChainType:    0,
-		ContractAddr: "osmo1zck32had0fpc4fu34ae58zvs3mjd5yrzs70thw027nfqst7edc3sdqak0m",
+		ContractAddr: "sei18fs8atjcxrsypskpk725q2vr8j76q3xwcfle3w2qlna48acmed0sp30xm8",
 	})
 
 	if err != nil {
@@ -30,16 +30,16 @@ func checkBlockFinalized(height uint64, hash string) {
 }
 
 func main() {
-	blockHashWithoutEnoughVotes := "0x3aa074144a25d3ed71c7353a20c579650e0c56a993444c6156d44bb90b932f0d"
-	blockHashWithEnoughVotes := "stub hash"
+	blockHash := "0x3aa074144a25d3ed71c7353a20c579650e0c56a993444c6156d44bb90b932f0d"
+	blockHashForked := "forked hash"
 
 	fmt.Println("=== When the block hash has enough votes: ===")
 	for i := range 4 {
-		checkBlockFinalized(uint64(i), blockHashWithEnoughVotes)
+		checkBlockFinalized(uint64(i), blockHash)
 	}
 
 	fmt.Println("\n=== When the block hash doesn't have enough votes: ===")
 	for i := range 4 {
-		checkBlockFinalized(uint64(i), blockHashWithoutEnoughVotes)
+		checkBlockFinalized(uint64(i), blockHashForked)
 	}
 }

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -26,7 +26,7 @@ type Config struct {
 func (config Config) getRpcAddr() (string, error) {
 	switch config.ChainType {
 	case BabylonTestnet:
-		return "https://rpc.testnet.osmosis.zone:443", nil
+		return "https://sei-testnet-2-rpc.brocha.in", nil
 	case BabylonMainnet:
 		return "https://rpc.testnet.osmosis.zone:443", nil
 	default:

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -20,23 +20,23 @@ func checkBlockFinalized(client *babylonQueryClient, height uint64, hash string)
 func TestSdk(t *testing.T) {
 	client, err := NewClient(Config{
 		ChainType:    0,
-		ContractAddr: "osmo1zck32had0fpc4fu34ae58zvs3mjd5yrzs70thw027nfqst7edc3sdqak0m",
+		ContractAddr: "sei18fs8atjcxrsypskpk725q2vr8j76q3xwcfle3w2qlna48acmed0sp30xm8",
 	})
 	require.Nil(t, err)
 
-	blockHashWithoutEnoughVotes := "0x3aa074144a25d3ed71c7353a20c579650e0c56a993444c6156d44bb90b932f0d"
-	blockHashWithEnoughVotes := "stub hash"
+	blockHash := "0x3aa074144a25d3ed71c7353a20c579650e0c56a993444c6156d44bb90b932f0d"
+	blockHashForked := "forked hash"
 
 	// When the block hash has enough votes
 	for i, expected := range []bool{true, true, true, false} {
-		finaliezd, err := checkBlockFinalized(client, uint64(i), blockHashWithEnoughVotes)
+		finaliezd, err := checkBlockFinalized(client, uint64(i), blockHash)
 		require.Nil(t, err)
 		require.Equal(t, expected, finaliezd)
 	}
 
 	// When the block hash doesn't have enough votes
 	for i := range 4 {
-		finaliezd, err := checkBlockFinalized(client, uint64(i), blockHashWithoutEnoughVotes)
+		finaliezd, err := checkBlockFinalized(client, uint64(i), blockHashForked)
 		require.Nil(t, err)
 		require.False(t, finaliezd)
 	}


### PR DESCRIPTION
## Summary
per [discussion](https://github.com/babylonchain/babylon-private/pull/260#issuecomment-2179644623) w @SebastianElvis and @mauroalacy, we won't have a query on Babylon chain to return consumer chain voting power

instead, those computation will be off-chain, handled by this SDK

this PR is the first step to incorporate the changes in https://github.com/babylonchain/babylon-contract/pull/178 to first get the list of all FPs that voted for the specific blockHeight-blockHash combination

Note: I also moved the stub contract to Sei b/c the Osmosis testnet is bad (took us 1 hr to debug only to find out it's their testnet issue). I consulted a few experts who told me Sei is awesome and Neutron can be used as a backup.

## Test Plan

```
make test
make run
```