### PR TITLE
chore: remove `rpcclient`

### DIFF
--- a/demo/main.go
+++ b/demo/main.go
@@ -9,7 +9,7 @@ import (
 func checkBlockFinalized(height uint64, hash string) {
 	client, err := sdk.NewClient(sdk.Config{
 		ChainType:    0,
-		ContractAddr: "sei18fs8atjcxrsypskpk725q2vr8j76q3xwcfle3w2qlna48acmed0sp30xm8",
+		ContractAddr: "bbn1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqztltxv",
 	})
 
 	if err != nil {

--- a/demo/main.go
+++ b/demo/main.go
@@ -9,7 +9,7 @@ import (
 func checkBlockFinalized(height uint64, hash string) {
 	client, err := sdk.NewClient(sdk.Config{
 		ChainType:    0,
-		ContractAddr: "bbn1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqztltxv",
+		ContractAddr: "bbn17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgs6spw0g",
 	})
 
 	if err != nil {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -9,7 +9,6 @@ import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	bbnclient "github.com/babylonchain/babylon/client/client"
 	bbncfg "github.com/babylonchain/babylon/client/config"
-	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"go.uber.org/zap"
 )
@@ -29,7 +28,7 @@ type Config struct {
 func (config Config) getRpcAddr() (string, error) {
 	switch config.ChainType {
 	case BabylonTestnet:
-		return "https://sei-testnet-2-rpc.brocha.in", nil
+		return "https://rpc-euphrates.devnet.babylonchain.io/", nil
 	case BabylonMainnet:
 		return "https://rpc.testnet.osmosis.zone:443", nil
 	default:
@@ -41,8 +40,6 @@ func (config Config) getRpcAddr() (string, error) {
 // It only requires the client config to have `rpcAddr`, but not other fields
 // such as keyring, chain ID, etc..
 type babylonQueryClient struct {
-	// TODO: remove rpcClient after the Babylon testnet supports cw
-	rpcClient rpcclient.Client
 	bbnClient *bbnclient.Client
 	config    *Config
 }
@@ -54,14 +51,8 @@ func NewClient(config Config) (*babylonQueryClient, error) {
 		return nil, err
 	}
 
-	rpcClient, err := sdkclient.NewClientFromNode(rpcAddr)
-	if err != nil {
-		return nil, err
-	}
-
 	bbnConfig := bbncfg.DefaultBabylonConfig()
-	// TODO: replace it with config.getRpcAddr() after the Babylon testnet supports cw
-	bbnConfig.RPCAddr = "https://rpc-euphrates.devnet.babylonchain.io/"
+	bbnConfig.RPCAddr = rpcAddr
 
 	logger, err := zap.NewProduction()
 	if err != nil {
@@ -79,7 +70,6 @@ func NewClient(config Config) (*babylonQueryClient, error) {
 	}
 
 	return &babylonQueryClient{
-		rpcClient: rpcClient,
 		bbnClient: bbnClient,
 		config:    &config,
 	}, nil
@@ -92,7 +82,7 @@ func (babylonClient *babylonQueryClient) querySmartContractState(contractAddress
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	sdkClientCtx := sdkclient.Context{Client: babylonClient.rpcClient}
+	sdkClientCtx := sdkclient.Context{Client: babylonClient.bbnClient.RPCClient}
 	wasmQueryClient := wasmtypes.NewQueryClient(sdkClientCtx)
 
 	req := &wasmtypes.QuerySmartContractStateRequest{

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -24,13 +24,13 @@ type Config struct {
 	ContractAddr string `mapstructure:"contract-addr"`
 }
 
-// TODO: replace with babylon RPCs when QuerySmartContractStateRequest query is supported
 func (config Config) getRpcAddr() (string, error) {
 	switch config.ChainType {
 	case BabylonTestnet:
 		return "https://rpc-euphrates.devnet.babylonchain.io/", nil
+	// TODO: replace with babylon RPCs when QuerySmartContractStateRequest query is supported
 	case BabylonMainnet:
-		return "https://rpc.testnet.osmosis.zone:443", nil
+		return "https://rpc-euphrates.devnet.babylonchain.io/", nil
 	default:
 		return "", fmt.Errorf("unrecognized chain type: %d", config.ChainType)
 	}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -84,14 +84,11 @@ func (babylonClient *babylonQueryClient) QueryIsBlockBabylonFinalized(queryParam
 
 	// TODO: change w real implementation
 	var consumerId = ""
-	allFps, err := babylonClient.queryFinalityProviders(consumerId)
+	_, err = babylonClient.queryFinalityProviders(consumerId)
 	if err != nil {
 		return false, err
 	}
-	for _, fp := range allFps {
-		// TODO: change w real implementation
-		println(fp.BtcPk)
-	}
+
 	// TODO: change w real implementation
 	// stub contract: https://www.seiscan.app/atlantic-2/query?contract=sei18fs8atjcxrsypskpk725q2vr8j76q3xwcfle3w2qlna48acmed0sp30xm8
 	// stub contract code: https://gist.github.com/bap2pecs/9541adb2ba61e7abb481bf03f863435d

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -20,7 +20,7 @@ func checkBlockFinalized(client *babylonQueryClient, height uint64, hash string)
 func TestSdk(t *testing.T) {
 	client, err := NewClient(Config{
 		ChainType:    0,
-		ContractAddr: "sei18fs8atjcxrsypskpk725q2vr8j76q3xwcfle3w2qlna48acmed0sp30xm8",
+		ContractAddr: "bbn17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgs6spw0g",
 	})
 	require.Nil(t, err)
 


### PR DESCRIPTION
This PR removes the `rpcclient` and runs the test with the Babylon devnet RPC.