### PR TITLE
feat: add queryConsumerChainId

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -87,7 +87,7 @@ func (babylonClient *babylonQueryClient) queryFinalityProviders(consumerId strin
 	return resp.FinalityProviders, nil
 }
 
-func (babylonClient *babylonQueryClient) queryConsumerChainId() (string, error) {
+func (babylonClient *babylonQueryClient) queryConsumerId() (string, error) {
 	queryData, err := createConfigQueryData()
 	if err != nil {
 		return "", err
@@ -112,12 +112,12 @@ func (babylonClient *babylonQueryClient) QueryIsBlockBabylonFinalized(queryParam
 		return false, err
 	}
 
-	consumerChainId, err := babylonClient.queryConsumerChainId()
+	consumerId, err := babylonClient.queryConsumerId()
 	if err != nil {
 		return false, err
 	}
 
-	_, err = babylonClient.queryFinalityProviders(consumerChainId)
+	_, err = babylonClient.queryFinalityProviders(consumerId)
 	if err != nil {
 		return false, err
 	}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -34,6 +34,17 @@ type blockVotesResponse struct {
 	BtcPkHexList []string `json:"fp_pubkey_hex_list"`
 }
 
+func createConfigQueryData() ([]byte, error) {
+	queryData := ContractQueryMsgs{
+		Config: &contractConfig{},
+	}
+	data, err := json.Marshal(queryData)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
 func createBlockVotesQueryData(queryParams QueryParams) ([]byte, error) {
 	queryData := ContractQueryMsgs{
 		BlockVotes: &blockVotes{
@@ -76,15 +87,37 @@ func (babylonClient *babylonQueryClient) queryFinalityProviders(consumerId strin
 	return resp.FinalityProviders, nil
 }
 
+func (babylonClient *babylonQueryClient) queryConsumerChainId() (string, error) {
+	queryData, err := createConfigQueryData()
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := babylonClient.querySmartContractState(babylonClient.config.ContractAddr, queryData)
+	if err != nil {
+		return "", err
+	}
+
+	var data contractConfigResponse
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return "", err
+	}
+
+	return data.ConsumerId, nil
+}
+
 func (babylonClient *babylonQueryClient) QueryIsBlockBabylonFinalized(queryParams QueryParams) (bool, error) {
 	votedFps, err := babylonClient.queryListOfVotedFinalityProviders(queryParams)
 	if err != nil {
 		return false, err
 	}
 
-	// TODO: change w real implementation
-	var consumerId = ""
-	_, err = babylonClient.queryFinalityProviders(consumerId)
+	consumerChainId, err := babylonClient.queryConsumerChainId()
+	if err != nil {
+		return false, err
+	}
+
+	_, err = babylonClient.queryFinalityProviders(consumerChainId)
 	if err != nil {
 		return false, err
 	}

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -18,9 +18,9 @@ func newE2eClientWithStubContract() *babylonQueryClient {
 	return client
 }
 
-func TestQueryConsumerChainId(t *testing.T) {
+func TestQueryConsumerId(t *testing.T) {
 	client := newE2eClientWithStubContract()
-	chainId, err := client.queryConsumerChainId()
+	chainId, err := client.queryConsumerId()
 	require.Nil(t, err)
 	require.Equal(t, "op-stack-l2-12345", chainId)
 }

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -6,6 +6,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newE2eClientWithStubContract() *babylonQueryClient {
+	stubContractConfig := Config{
+		ChainType:    0,
+		ContractAddr: "bbn17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgs6spw0g",
+	}
+	client, err := NewClient(stubContractConfig)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+func TestQueryConsumerChainId(t *testing.T) {
+	client := newE2eClientWithStubContract()
+	chainId, err := client.queryConsumerChainId()
+	require.Nil(t, err)
+	require.Equal(t, "op-stack-l2-12345", chainId)
+}
+
 // this uses a stub contract deployed on Osmosis testnet
 // TODO: replace with one deployed on Babylon chain
 func checkBlockFinalized(client *babylonQueryClient, height uint64, hash string) (bool, error) {
@@ -18,11 +37,7 @@ func checkBlockFinalized(client *babylonQueryClient, height uint64, hash string)
 
 // TestSdk is an e2e test to call into a stub CosmWasm contract deployed on Osmosis testnet
 func TestSdk(t *testing.T) {
-	client, err := NewClient(Config{
-		ChainType:    0,
-		ContractAddr: "bbn17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgs6spw0g",
-	})
-	require.Nil(t, err)
+	client := newE2eClientWithStubContract()
 
 	blockHash := "0x3aa074144a25d3ed71c7353a20c579650e0c56a993444c6156d44bb90b932f0d"
 	blockHashForked := "forked hash"


### PR DESCRIPTION
## Summary

query consumer chain id from the CW contract’s `CONFIG` state. this is needed to fetch all registered FPs for the consumer chain

I also refactored test a bit to extract common logic to `newE2eClientWithStubContract`

## Test Plan

```
make test
make run
```

Note: the stub contract was deployed to Babylon devnet. the exact same contract was deployed to https://www.seiscan.app/atlantic-2/query?contract=sei16ckfmlym6wv5hwptuzpeumen028cu065a77ypj4dp7k56fsmj9hqx6t4gy

the stub code: https://gist.github.com/bap2pecs/dab60fa5371b33ba5fc972d9986118f2