### PR TITLE
feat: downgrade to go 1.21 for compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/babylonchain/babylon-da-sdk
 
-go 1.22.4
+go 1.21
 
 require (
 	github.com/CosmWasm/wasmd v0.51.0


### PR DESCRIPTION
## Summary

`babylon/optimism` uses Go 1.21, whereas this SDK currently uses Go 1.22.4

This causes dependency mismatch issues, so we need to downgrade our Go version for compatibility