### PR TITLE
feat: add CW queries and implement killswitch

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -17,6 +17,7 @@ type QueryParams struct {
 type ContractQueryMsgs struct {
 	Config     *contractConfig `json:"config,omitempty"`
 	BlockVotes *blockVotes     `json:"block_votes,omitempty"`
+	IsDisabled *isDisabledQuery `json:"is_disabled,omitempty"`
 }
 
 type contractConfig struct{}
@@ -33,6 +34,12 @@ type blockVotes struct {
 
 type blockVotesResponse struct {
 	BtcPkHexList []string `json:"fp_pubkey_hex_list"`
+}
+
+type isDisabledQuery struct {}
+
+type isDisabledResponse struct {
+	IsDisabled bool `json:"is_disabled"`
 }
 
 func createConfigQueryData() ([]byte, error) {
@@ -124,6 +131,16 @@ func queryMultiFpPowerAtHeight(fps []string, btcHeight uint64) (map[string]uint6
 }
 
 func (babylonClient *babylonQueryClient) QueryIsBlockBabylonFinalized(queryParams QueryParams) (bool, error) {
+	// check if the contract is disabled
+	// if so, return true to pass through op derivation pipeline
+	isDisabled, err := babylonClient.queryIsDisabled()
+	if err != nil {
+		return false, err
+	}
+	if isDisabled {
+		return true, nil
+	}
+
 	// get the consumer chain id
 	consumerId, err := babylonClient.queryConsumerId()
 	if err != nil {
@@ -174,4 +191,34 @@ func (babylonClient *babylonQueryClient) QueryIsBlockBabylonFinalized(queryParam
 		return false, errors.New("not enough voting power")
 	}
 	return true, nil
+}
+
+func createIsDisabledQueryData() ([]byte, error) {
+	queryData := ContractQueryMsgs{
+		IsDisabled: &isDisabledQuery{},
+	}
+	data, err := json.Marshal(queryData)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (babylonClient *babylonQueryClient) queryIsDisabled() (bool, error) {
+	queryData, err := createIsDisabledQueryData()
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := babylonClient.querySmartContractState(babylonClient.config.ContractAddr, queryData)
+	if err != nil {
+		return false, err
+	}
+
+	var data isDisabledResponse
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return false, err
+	}
+
+	return data.IsDisabled, nil
 }


### PR DESCRIPTION
## Summary

This PR adds support for a killswitch feature. It closes #21.

## Description

When calling `QueryIsBlockBabylonFinalized`, we first query the `is_disabled` state variable in the CW contract and, if true, disable the EOTS verification step by returning true.

This effectively builds in a killswitch that allows the OP derivation pipeline to pass through.

See also https://github.com/babylonchain/babylon-contract/issues/181 which contains corresponding updates to CW contract to expose new query methods

## Test plan

```
make run
make test
```