### PR TITLE
fix: killswitch response type and update var naming for consistency

### DIFF
--- a/cw-da-contract-stub/Makefile
+++ b/cw-da-contract-stub/Makefile
@@ -11,6 +11,10 @@ build:
 	cargo schema
 	RUSTFLAGS='$(RUSTFLAGS)' cargo wasm
 
+# Generate wasm
+wasm:
+	cargo build --release --target wasm32-unknown-unknown --lib
+
 # Clean target
 clean:
 	cargo clean

--- a/cw-da-contract-stub/src/contract.rs
+++ b/cw-da-contract-stub/src/contract.rs
@@ -17,7 +17,7 @@ pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Config {} => Ok(to_json_binary(&query::query_config()?)?),
         BlockVotes { height, hash } => to_json_binary(&query::block_votes(height, hash)?),
-        QueryMsg::IsEnabled {} => Ok(to_json_binary(&query::query_ks()?)?),
+        QueryMsg::IsEnabled {} => Ok(to_json_binary(&query::query_is_enabled()?)?),
     }
 }
 
@@ -37,7 +37,7 @@ mod query {
         return Ok(config);
     }
 
-    pub fn query_ks() -> StdResult<bool> {
+    pub fn query_is_enabled() -> StdResult<bool> {
         return Ok(true);
     }
 

--- a/demo/main.go
+++ b/demo/main.go
@@ -9,7 +9,7 @@ import (
 func checkBlockFinalized(height uint64, hash string) {
 	client, err := sdk.NewClient(sdk.Config{
 		ChainType:    0,
-		ContractAddr: "bbn17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgs6spw0g",
+		ContractAddr: "bbn1eyfccmjm6732k7wp4p6gdjwhxjwsvje44j0hfx8nkgrm8fs7vqfsa3n3gc",
 	})
 
 	if err != nil {

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -18,7 +18,7 @@ type QueryParams struct {
 type ContractQueryMsgs struct {
 	Config     *contractConfig `json:"config,omitempty"`
 	BlockVotes *blockVotes     `json:"block_votes,omitempty"`
-	IsEnabled *killswitchQuery `json:"is_enabled,omitempty"`
+	IsEnabled *isEnabledQuery `json:"is_enabled,omitempty"`
 }
 
 type contractConfig struct{}
@@ -37,11 +37,7 @@ type blockVotesResponse struct {
 	BtcPkHexList []string `json:"fp_pubkey_hex_list"`
 }
 
-type killswitchQuery struct {}
-
-type killswitchResponse struct {
-	IsEnabled bool `json:"is_enabled"`
-}
+type isEnabledQuery struct {}
 
 func createConfigQueryData() ([]byte, error) {
 	queryData := ContractQueryMsgs{
@@ -267,7 +263,7 @@ func (babylonClient *babylonQueryClient) QueryIsBlockBabylonFinalized(queryParam
 
 func createIsEnabledQueryData() ([]byte, error) {
 	queryData := ContractQueryMsgs{
-		IsEnabled: &killswitchQuery{},
+		IsEnabled: &isEnabledQuery{},
 	}
 	data, err := json.Marshal(queryData)
 	if err != nil {
@@ -287,10 +283,10 @@ func (babylonClient *babylonQueryClient) queryIsEnabled() (bool, error) {
 		return false, err
 	}
 
-	var data killswitchResponse
-	if err := json.Unmarshal(resp.Data, &data); err != nil {
+	var isEnabled bool
+	if err := json.Unmarshal(resp.Data, &isEnabled); err != nil {
 		return false, err
 	}
 
-	return data.IsEnabled, nil
+	return isEnabled, nil
 }


### PR DESCRIPTION
## Summary

1. Fixes #27. Corrects the `IsEnabled` response type to match the CW contract. We deploy a new stub contract and update the address so the test now passes.
2. Updates variable naming for consistency with CW contract updates: https://github.com/babylonchain/babylon-contract/pull/182/commits/3e08517f94dd84b05cc53351289cd3384dbf1d1b

## Test plan

```
make run
make test
```