### PR TITLE
test: add itest 2/x

### DIFF
--- a/itest/opstackl2/e2e_test.go
+++ b/itest/opstackl2/e2e_test.go
@@ -88,7 +88,7 @@ func TestBlockBabylonFinalized(t *testing.T) {
 		require.NoError(t, err)
 
 		// submit finality signature to smart contract
-		submitRes, err := stm.OpL2ConsumerCtrl.SubmitFinalitySig(
+		_, err = stm.OpL2ConsumerCtrl.SubmitFinalitySig(
 			fp.GetBtcPk(),
 			block,
 			pubRandList[0],
@@ -96,7 +96,7 @@ func TestBlockBabylonFinalized(t *testing.T) {
 			fpSig.ToModNScalar(),
 		)
 		require.NoError(t, err)
-		t.Logf("Submit finality signature to op finality contract %s", submitRes.TxHash)
+		t.Logf("Submit finality signature to op finality contract")
 	}
 
 	queryParams := sdk.QueryParams{


### PR DESCRIPTION
## Summary

This PR wants to add a test case in which the block is not finalized b/c it doesn't have enough voting power (i.e. <2/3).

It has two consumer FPs and two BTC delegations, the staking amount of one FP is triple that of the other. The FP with greater voting power is responsible for signing the first block, while the FP with smaller voting power signs the second block.


So we expect the first block to be finalized b/c it has 3/4 voting power and the second block would not be finalized b/c it has 1/4 voting power.

## Test Plan

```
make test-e2e
```

When running the test case, `FAIL` without any error, like this:

```
make test-e2e
Killed processes 60727 
cd tools; \
        go install -trimpath github.com/babylonchain/babylon/cmd/babylond
go test -mod=readonly -timeout=25m -v github.com/babylonchain/babylon-da-sdk/itest/opstackl2 -count=1 --tags=e2e_op
=== RUN   TestBlockBabylonFinalized
service injective.evm.v1beta1.Msg does not have cosmos.msg.v1.service proto annotation
    op_test_manager.go:86: Register consumer op-stack-l2-12345 to Babylon
service injective.evm.v1beta1.Msg does not have cosmos.msg.v1.service proto annotation
    op_test_manager.go:119: Deployed op finality contract address: bbn14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sw76fy2
    op_test_manager.go:191: Babylon node has started
service injective.evm.v1beta1.Msg does not have cosmos.msg.v1.service proto annotation
    op_test_manager.go:216: Registered Finality Provider cf23baf1f4f87fbc4705ec0e9fccc3b114072f683b9050201fb92880400fb242
    op_test_manager.go:260: The test manager is running with 1 finality-provider(s)
    op_test_manager.go:216: Registered Finality Provider 6c69b628f2cb3136873df40e008f68d8c79cd080dcf9dcd34ce4a702b51aa95c
    op_test_manager.go:216: Registered Finality Provider 9015cbb9591ed739f8114fe0ba600669a175483240ab1b9cd06531f44a92adf7
    op_test_manager.go:260: The test manager is running with 3 finality-provider(s)
    utils.go:92: Public randomness is successfully committed
    test_manager.go:177: successfully submitted a BTC delegation
    utils.go:92: Public randomness is successfully committed
    test_manager.go:177: successfully submitted a BTC delegation
    test_manager.go:210: delegations are pending
    test_manager.go:230: delegations are active
    e2e_test.go:62: Query pub rand via finality provider 9015cbb9591ed739f8114fe0ba600669a175483240ab1b9cd06531f44a92adf7
    e2e_test.go:67: Finality provider 6c69b628f2cb3136873df40e008f68d8c79cd080dcf9dcd34ce4a702b51aa95c
    e2e_test.go:75: Last committed pubrandList startHeight 20173414
FAIL    github.com/babylonchain/babylon-da-sdk/itest/opstackl2  160.254s
FAIL
```

@SebastianElvis do you have any ideas?