### PR TITLE
fix: skip the L2 block 

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -240,7 +240,8 @@ func (babylonClient *BabylonQueryClient) QueryIsBlockBabylonFinalized(queryParam
 
 	// no FP has voting power for the consumer chain
 	if totalPower == 0 {
-		return false, nil
+		// skip the block if no FP has voting power
+		return true, nil
 	}
 
 	// get all FPs that voted this (L2 block height, L2 block hash) combination


### PR DESCRIPTION
This PR fixes the issue of `QueryIsBlockBabylonFinalized`, it should return `true` when no FP has voting power at a height.

