### PR TITLE
fix: unmarshal json error

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,3 @@
-run:
-  build-tags: 
-    - e2e_op
-    - e2e_babylon
-    - e2e_bcd
-    - e2e_wasmd
-
 linters-settings:
   govet:
       enable-all: true

--- a/sdk/btc/btc.go
+++ b/sdk/btc/btc.go
@@ -27,7 +27,7 @@ type rpcResponse struct {
 	Result json.RawMessage `json:"result"`
 }
 
-func callRPC(rpcURL string, method string, params []interface{}) (json.RawMessage, error) {
+func callRPC(method string, params []interface{}) (json.RawMessage, error) {
 	var responseResult json.RawMessage
 	maxRetries := 5
 	retryInterval := 500 * time.Millisecond


### PR DESCRIPTION
## Summary

This PR fixes the unmarshal JSON error from the op e2e test case, it is caused by the null response of the RPC call occasionally, so we added a retry mechanism for the RPC call to fix it.

```
state.go:371:               ERROR[07-03|09:02:44.532] Derivation process critical error        role=sequencer err="failed to check if block 6 is finalized on Babylon: unexpected end of JSON input"
```

## Test Plan

```
make lint
make test
make run
```